### PR TITLE
Correction to help: Sharing of collections and albums

### DIFF
--- a/src/main/webapp/resources/Help.html
+++ b/src/main/webapp/resources/Help.html
@@ -301,8 +301,8 @@ Assign /Edit metadata values:</span></p>
 <h3 class="imj_sectionHeadline" style="padding:0"><a name="2.7._Share_Collection"></a>2.7. Share a Collection</h3>
 
 <p>
-<span style="text-decoration: underline">Note</span>: You can only share 
-private collections with existing users or user groups. Please contact the 
+<span style="text-decoration: underline">Note</span>: Collections can only
+be shared with existing users or user groups. Please contact the 
 <span style="font-style: italic;"><a href="mailto:XXX_SUPPORT_EMAIL_XXX">support team</a></span> 
 to request additional accounts or groups.</p>
 
@@ -380,8 +380,7 @@ of deleted.</p>
 Albums are similar to photo albums in the non digital world or baskets in an
 online shops. In an album, the user can collect items from one or several 
 collections, thus the items may have been described by different metadata 
-profiles. Albums can be used to group items according to thematic aspects or 
-to provide access to selected items.</p>
+profiles. Albums can be used to group items according to a thematic aspect.</p>
 
 
 <br/>
@@ -482,8 +481,8 @@ it has been uploaded to.
 <h3 class="imj_sectionHeadline" style="padding:0"><a name="3.6._Share_Album"></a>3.6. Share Album</h3>
 
 <p>
-<span style="text-decoration: underline">Note</span>: You can only share 
-private albums with existing users or user groups. Please contact the 
+<span style="text-decoration: underline">Note</span>: Albums can only 
+be shared with existing users or user groups. Please contact the 
 <span style="font-style: italic;"><a href="mailto:XXX_SUPPORT_EMAIL_XXX">support team</a></span> 
 to request additional accounts or groups.</p>
 
@@ -496,7 +495,14 @@ to request additional accounts or groups.</p>
   <li>Enter the email address of the user or select the user group.</li>
   <li>Choose the grants you want to assign to the user or the user group.</li>
   <li>Click on <span style="font-style: italic;">Save</span>.</li>
+  <li></li> 
 </ul>
+
+<p>
+<span style="text-decoration: underline">Note</span>: Sharing albums does  
+does not share all included items automatically. Thus, the receiving user 
+can only access the album's items if they are visible to him.
+</p>
 
 
 <br/>

--- a/src/main/webapp/resources/Help.html
+++ b/src/main/webapp/resources/Help.html
@@ -1,5 +1,4 @@
 <h1>Help</h1>
-<h1>Help</h1>
 
 <hr style="width: 100%; height: 2px;">
 
@@ -495,7 +494,6 @@ to request additional accounts or groups.</p>
   <li>Enter the email address of the user or select the user group.</li>
   <li>Choose the grants you want to assign to the user or the user group.</li>
   <li>Click on <span style="font-style: italic;">Save</span>.</li>
-  <li></li> 
 </ul>
 
 <p>


### PR DESCRIPTION
- public collections and albums may be shared as well (e.g. to provide edit/admin grants to published containers)
- sharing of an album does not share the included items